### PR TITLE
Develop

### DIFF
--- a/PersonalNewsSiteSupportTool/Models/PathManager.cs
+++ b/PersonalNewsSiteSupportTool/Models/PathManager.cs
@@ -25,17 +25,5 @@ namespace PersonalNewsSiteSupportTool.Models
         {
             return APP_PATH;
         }
-
-        public static string GetFullPath(string folder, string filename)
-        {
-            if (folder.EndsWith("\\"))
-            {
-                return folder + filename;
-            }
-            else
-            {
-                return folder + "\\" + filename;
-            }
-        }
     }
 }

--- a/PersonalNewsSiteSupportTool/Models/PathManager.cs
+++ b/PersonalNewsSiteSupportTool/Models/PathManager.cs
@@ -25,5 +25,17 @@ namespace PersonalNewsSiteSupportTool.Models
         {
             return APP_PATH;
         }
+
+        public static string GetFullPath(string folder, string filename)
+        {
+            if (folder.EndsWith("\\"))
+            {
+                return folder + filename;
+            }
+            else
+            {
+                return folder + "\\" + filename;
+            }
+        }
     }
 }

--- a/PersonalNewsSiteSupportTool/ViewModels/MainWindowModel.cs
+++ b/PersonalNewsSiteSupportTool/ViewModels/MainWindowModel.cs
@@ -339,7 +339,7 @@ namespace PersonalNewsSiteSupportTool.ViewModels
         {
             try
             {
-                File.AppendAllText($"{folder}{fileName}", outText);
+                File.AppendAllText(PathManager.GetFullPath(folder, fileName), outText);
             }
             catch (PathTooLongException e)
             {
@@ -377,7 +377,8 @@ namespace PersonalNewsSiteSupportTool.ViewModels
         /// <returns>出力の成否</returns>
         private bool OverwriteTextFile(string folder, string fileName, string outText)
         {
-            if (File.Exists($"{folder}{fileName}"))
+            string fullPath = PathManager.GetFullPath(folder, fileName);
+            if (File.Exists(fullPath))
             {
                 if (!ShowConfirmMessage("出力先にファイルがありますが上書きしますか？"))
                 {
@@ -386,11 +387,11 @@ namespace PersonalNewsSiteSupportTool.ViewModels
             }
             try
             {
-                File.WriteAllText($"{folder}{fileName}", outText);
+                File.WriteAllText(fullPath, outText);
             }
             catch (PathTooLongException e)
             {
-                ShowErrorMessage($"出力先のファイルパスが長すぎます。\n{folder}{fileName}");
+                ShowErrorMessage($"出力先のファイルパスが長すぎます。\n{fullPath}");
                 LogService.DumpException(e);
                 return false;
             }

--- a/PersonalNewsSiteSupportTool/ViewModels/MainWindowModel.cs
+++ b/PersonalNewsSiteSupportTool/ViewModels/MainWindowModel.cs
@@ -339,7 +339,7 @@ namespace PersonalNewsSiteSupportTool.ViewModels
         {
             try
             {
-                File.AppendAllText(PathManager.GetFullPath(folder, fileName), outText);
+                File.AppendAllText(Path.Combine(folder, fileName), outText);
             }
             catch (PathTooLongException e)
             {
@@ -377,7 +377,7 @@ namespace PersonalNewsSiteSupportTool.ViewModels
         /// <returns>出力の成否</returns>
         private bool OverwriteTextFile(string folder, string fileName, string outText)
         {
-            string fullPath = PathManager.GetFullPath(folder, fileName);
+            string fullPath = Path.Combine(folder, fileName);
             if (File.Exists(fullPath))
             {
                 if (!ShowConfirmMessage("出力先にファイルがありますが上書きしますか？"))

--- a/UnitTestProject/Models/CommonUtilTest.cs
+++ b/UnitTestProject/Models/CommonUtilTest.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PersonalNewsSiteSupportTool.Models;
 
-namespace UnitTestProject
+namespace UnitTestProject.Models
 {
     [TestClass]
     public class CommonUtilTest : TestBase
@@ -9,7 +9,7 @@ namespace UnitTestProject
         [ClassInitialize()]
         public static void MyClassInitialize(TestContext testContext)
         {
-            ClassInit();
+            ClassInit(testContext);
         }
 
         [ClassCleanup()]

--- a/UnitTestProject/Models/ConfigManagerTest.cs
+++ b/UnitTestProject/Models/ConfigManagerTest.cs
@@ -4,7 +4,7 @@ using System;
 using System.IO;
 using System.Collections.Generic;
 
-namespace UnitTestProject
+namespace UnitTestProject.Models
 {
     [TestClass]
     public class ConfigManagerTest :TestBase
@@ -12,7 +12,7 @@ namespace UnitTestProject
         [ClassInitialize()]
         public static void MyClassInitialize(TestContext testContext)
         {
-            ClassInit();
+            ClassInit(testContext);
         }
 
         [ClassCleanup()]

--- a/UnitTestProject/Models/LogServiceTest.cs
+++ b/UnitTestProject/Models/LogServiceTest.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NLog;
+using NLog.Targets;
+using PersonalNewsSiteSupportTool.Models;
+using System;
+using System.IO;
+
+namespace UnitTestProject.Models
+{
+    [TestClass]
+    public class LogServiceTest : TestBase
+    {
+        [ClassInitialize()]
+        public static void MyClassInitialize(TestContext testContext)
+        {
+            ClassInit(testContext);
+        }
+
+        [ClassCleanup()]
+        public static void MyClassCleanup()
+        {
+            ClassClean();
+        }
+
+        [TestMethod][Ignore("今の構成ではうまく動かないので対象外。そもそも、実装側を少し手を入れたほうがよさそう。")]
+        public void TestInit()
+        {
+            var logPath = @"..\..\ResultData\logs";
+            var debugPath = logPath + @"\debug.log";
+            var errorPath = logPath + @"\error.log";
+            var logService = new PrivateType(typeof(LogService));
+            var originalLogPath = logService.GetStaticFieldOrProperty("logPath");
+            try
+            {
+                // テスト用にログパスと初期化フラグを書換え
+                logService.SetStaticFieldOrProperty("logPath", logPath);
+                logService.SetStaticFieldOrProperty("isInit", false);
+                if (Directory.Exists(logPath))
+                {
+                    File.Delete(debugPath);
+                    File.Delete(errorPath);
+                    Directory.Delete(logPath);
+                }
+                LogService.Init();
+                var config = LogManager.Configuration;
+                Console.WriteLine(config.FindTargetByName<FileTarget>("debugLog").FileName);
+                Console.WriteLine(config.FindTargetByName<FileTarget>("errorLog").FileName);
+                Assert.IsTrue(File.Exists(debugPath), "ファイルが作成されていません。" + debugPath);
+                Assert.IsTrue(File.Exists(errorPath), "ファイルが作成されていません。" + errorPath);
+
+                // テスト用に初期化フラグを書換え
+                logService.SetStaticFieldOrProperty("isInit", false);
+                LogService.Init();
+            }
+            finally
+            {
+                // 他のテストのために値を戻す。
+                logService.SetStaticFieldOrProperty("logPath", originalLogPath);
+            }
+        }
+    }
+}

--- a/UnitTestProject/TestBase.cs
+++ b/UnitTestProject/TestBase.cs
@@ -14,7 +14,7 @@ namespace UnitTestProject
 
         protected const string TEST_CONFIG_PATH = @"..\..\TestData\comfig.json";
 
-        protected static void ClassInit()
+        protected static void ClassInit(TestContext testContext)
         {
             // アプリケーションデータパスを書換え
             var pathManager = new PrivateType(typeof(PathManager));

--- a/UnitTestProject/TestBase.cs
+++ b/UnitTestProject/TestBase.cs
@@ -101,7 +101,7 @@ namespace UnitTestProject
             }
         }
 
-        protected void AssertFile(string expFilePath, string actFilePath, string msg = "")
+        protected static void AssertFile(string expFilePath, string actFilePath, string msg = "")
         {
             CollectionAssert.AreEqual(System.IO.File.ReadAllBytes(expFilePath), System.IO.File.ReadAllBytes(actFilePath), msg);
         }

--- a/UnitTestProject/UnitTest2.cs
+++ b/UnitTestProject/UnitTest2.cs
@@ -49,7 +49,7 @@ namespace UnitTestProject
         [ClassInitialize()]
         public static void MyClassInitialize(TestContext testContext)
         {
-            ClassInit();
+            ClassInit(testContext);
         }
         //
         // クラス内のテストをすべて実行したら、ClassCleanup を使用してコードを実行してください

--- a/UnitTestProject/UnitTestProject.csproj
+++ b/UnitTestProject/UnitTestProject.csproj
@@ -49,8 +49,9 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="CommonUtilTest.cs" />
-    <Compile Include="ConfigManagerTest.cs" />
+    <Compile Include="Models\CommonUtilTest.cs" />
+    <Compile Include="Models\ConfigManagerTest.cs" />
+    <Compile Include="Models\LogServiceTest.cs" />
     <Compile Include="TestBase.cs" />
     <Compile Include="UnitTest1.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
ファイルの保存パス結合処理をPath.Combineを使用するように修正（https://github.com/kurodenimu/PersonalNewsSiteSupportTool/issues/59 [フォルダ名の末尾について\の有無に関わらず動作するように修正](https://github.com/kurodenimu/PersonalNewsSiteSupportTool/commit/4a6f1c63907d8fc84d001b54f2fa057f0af84c18)）
その他、テストクラスの追加・修正